### PR TITLE
Fix CI: clear high-severity dev dependency advisories and repair the Renovate schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,9 @@ on:
   release:
     types: [published]
   schedule:
-    - cron: "0 9 * * 1"
+    # Late Monday UTC, after Renovate's all-Monday window has had time to open
+    # and auto-merge the weekly lock file maintenance PR.
+    - cron: "0 22 * * 1"
 
 jobs:
   test:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1597,16 +1597,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/chai": {
@@ -3403,9 +3403,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -3566,9 +3566,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -3586,7 +3586,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":enableVulnerabilityAlerts"],
-  "schedule": ["before 9am on Monday"],
+  "schedule": ["* * * * 1"],
   "timezone": "UTC",
   "automerge": false,
   "lockFileMaintenance": {
+    "description": "Refresh the lockfile weekly so transitive advisories do not accumulate between direct-dependency bumps",
     "enabled": true,
-    "schedule": ["before 9am on Monday"],
+    "schedule": ["* * * * 1"],
     "automerge": true
   },
   "packageRules": [


### PR DESCRIPTION
## What broke

The weekly scheduled run ([30265550440](https://github.com/gjkoplik/hiveplotlib-javascript/actions/runs/30265550440)) failed on `npm audit --audit-level=high`. Lint, formatting, all 109 tests at 100% coverage, and the build passed. Only the audit step failed.

Two advisories were published against transitive dev dependencies already pinned in the lockfile:

| Package | Locked | Advisory | Pulled in by |
| --- | --- | --- | --- |
| `brace-expansion` | 5.0.7 | [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg), DoS | eslint → minimatch |
| `postcss` | 8.5.16 | [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849), path traversal | vitest → vite |

No code changed, and neither package reaches the published artifact.

## The lockfile fix

`npm audit fix --package-lock-only`, without `--force`, so `package.json` is untouched:

- `brace-expansion` 5.0.7 → 5.0.8
- `postcss` 8.5.16 → 8.5.23
- `nanoid` 3.3.15 → 3.3.16, pulled along by postcss

## Why this is the second time

#33 hit the same two packages a month ago and enabled `lockFileMaintenance` to prevent exactly this. That maintenance has never run. On the [dependency dashboard](https://github.com/gjkoplik/hiveplotlib-javascript/issues/30), lock file maintenance and eight other updates are all sitting in **Awaiting Schedule**.

The window `before 9am on Monday` is nine hours wide, so Renovate's hosted scheduler has to happen to run inside it. Worse, the CI cron was `0 9 * * 1`, firing at the exact moment that window closed. A lock PR auto-merged at 08:50 UTC would still have missed that morning's audit.

So two changes here:

- Widen the top-level and `lockFileMaintenance` schedules to all of Monday (`* * * * 1`).
- Move the CI cron to 22:00 UTC Monday, leaving the full day for Renovate to open and auto-merge the lockfile PR before the audit runs.

## Verification

Against a fresh `npm ci`:

- `npm run lint` clean
- `npm run format:check` clean
- `npm test`: 109/109 passing, 100% statements, branches, functions, and lines
- `npm audit --audit-level=high`: 0 vulnerabilities
- `npm run build`: both bundles emit (6.3kb, 7.2kb)
- `renovate-config-validator`: config validated successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
