### PR TITLE
Update CI matrix to Node 22/24/26 and add a 3-day dependency cooling-off

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        node-version: [22, 24]
+        node-version: [22, 24, 26]
 
     steps:
       - name: Checkout repository

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   "schedule": ["* * * * 1"],
   "timezone": "UTC",
   "automerge": false,
+  "minimumReleaseAge": "3 days",
   "lockFileMaintenance": {
     "description": "Refresh the lockfile weekly so transitive advisories do not accumulate between direct-dependency bumps",
     "enabled": true,


### PR DESCRIPTION
Two changes that unblock [#39](https://github.com/gjkoplik/hiveplotlib-javascript/pull/39) and tighten the auto-merge policy.

## CI matrix: `[20, 22, 24]` to `[22, 24, 26]`

**Node 20 comes out** because jsdom v30 drops it on purpose. jsdom 30's `engines` are `^22.22.2 || ^24.15.0 || >=26.0.0`, and undici 8 (which jsdom 30 requires) does this at module load:

```js
const { markAsUncloneable } = require('node:worker_threads')
```

That export was added in Node v23.0.0 and backported to v22.10.0, so on Node 20 it resolves to `undefined` and the first DOM class instantiation throws `webidl.util.markAsUncloneable is not a function`. Node 20 also reached end of life on 2026-03-24.

**Node 26 goes in** because v26.6.0 is the current release line and people are running it today. It doesn't become LTS until October, but compatibility is worth verifying rather than assuming for a published package.

All three versions pass.

`engines` stays at `">=20"`. jsdom is a devDependency and never reaches the published bundle, so nothing here changes for consumers of `@hiveplotlib/d3`.

## Add a 3-day cooling-off period

```json
"minimumReleaseAge": "3 days"
```

Patch and minor devDependency updates currently auto-merge the moment CI goes green, which means a broken or compromised release can land without anyone looking at it. Holding new releases for three days covers the window in which most bad releases get spotted and pulled, and costs nothing at this project's update cadence.

## Merge order

This needs to land before #39, otherwise main goes red on the Node 20 job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
